### PR TITLE
Added Mac OS support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import json
 import os
 import platform

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import json
 import os
 import platform

--- a/main.py
+++ b/main.py
@@ -203,9 +203,9 @@ def makePaths(version):
 
 if __name__ == "__main__":
     print("Please Run once the snapshot/version on your computer via Minecraft Launcher so it can download it")
-    decompiler = input("Please input you decompiler choice: fernflower or cfr (default: cfr) : ")
-    decompiler = decompiler if decompiler in ["fernflower", "cfr"] else "cfr"
-    version = input("Please input a valid version starting from 19w36a : ") or "19w36a"
+    decompiler = input("Please input you decompiler choice: fernflower (f) or cfr (n) (default: fernflower): ")
+    decompiler = "cfr" if decompiler == "c" else "fernflower"
+    version = input("Please input a valid version starting from 19w36a: ") or "19w36a"
     decompVersion = makePaths(version)
     r = input('Download mappings? (y/n): ') or "y"
     if r == 'y':

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-mc_path = Path("~/Library/Application Support/minecraft") if platform.platform() == "Darwin" else Path("~/.minecraft") if os.name == "posix" else Path("~/AppData/Roaming/.minecraft")
+mc_path = Path("~/Library/Application Support/minecraft") if platform.system() == "Darwin" else Path("~/.minecraft") if os.name == "posix" else Path("~/AppData/Roaming/.minecraft")
 
 
 def downloadFile(url, filename):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import random
 import shutil
 import subprocess
@@ -9,7 +10,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-mc_path = Path("~/.minecraft") if os.name == "posix" else Path("~/AppData/Roaming/.minecraft")
+mc_path = Path("~/Library/Application Support/minecraft") if platform.platform() == "Darwin" else Path("~/.minecraft") if os.name == "posix" else Path("~/AppData/Roaming/.minecraft")
 
 
 def downloadFile(url, filename):


### PR DESCRIPTION
1. The minecraft folder is at ~/Library/Application Support/minecraft on Mac OS.
2. Unix requires a shebang and Unix line endings.
3. It takes a lot of time to type "fernflower", also it's more powerful, so make it the default.

Thanks for this amazing utility!