### PR TITLE
Disable "rename ambiguous" Fernflower option

### DIFF
--- a/main.py
+++ b/main.py
@@ -345,7 +345,6 @@ def decompile_fern_flower(decompiled_version, version, side, quiet, force):
                         '-hes=0',  # hide empty super invocation deactivated (might clutter but allow following)
                         '-hdc=0',  # hide empty default constructor deactivated (allow to track)
                         '-dgs=1',  # decompile generic signatures activated (make sure we can follow types)
-                        '-ren=1',  # rename ambiguous activated
                         '-lit=1',  # output numeric literals
                         '-asc=1',  # encode non-ASCII characters in string and character
                         '-log=WARN',


### PR DESCRIPTION
This option causes Fernflower to [rename identifiers](https://github.com/JetBrains/intellij-community/tree/master/plugins/java-decompiler/engine#renaming-identifiers) that are less than 3 characters, which is not what we want since Minecraft frequently uses identifiers less than 3 characters (for example "x").

Example of decompilation in `ClientboundAddPlayerPacket` before this change:
```java
   // $FF: renamed from: x double
   private final double field_323;
   // $FF: renamed from: y double
   private final double field_324;
   // $FF: renamed from: z double
   private final double field_325;
```
After:
```java
   private final double x;
   private final double y;
   private final double z;
```