### PR TITLE
Update manifest location

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from urllib.error import HTTPError, URLError
 
 assert sys.version_info >= (3, 7)
 
-MANIFEST_LOCATION = "https://launchermeta.mojang.com/mc/game/version_manifest.json"
+MANIFEST_LOCATION = "https://piston-meta.mojang.com/mc/game/version_manifest.json"
 CLIENT = "client"
 SERVER = "server"
 


### PR DESCRIPTION
Version manifest URL changed in 22w24a, 1.19.1-pre1 doesn't show up under the old URL