### PR TITLE
Use version manifest v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from urllib.error import HTTPError, URLError
 
 assert sys.version_info >= (3, 7)
 
-MANIFEST_LOCATION = "https://piston-meta.mojang.com/mc/game/version_manifest.json"
+MANIFEST_LOCATION = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json"
 CLIENT = "client"
 SERVER = "server"
 


### PR DESCRIPTION
version_manifest_v2.json updates faster than version_manifest.json, because Mojang. Unlike what the name suggests, it seems to have no breaking changes and only adds the `sha1` and `complianceLevel` fields.